### PR TITLE
Add 0.0.0.0/0 route if defaultGateway is true

### DIFF
--- a/src/OpenVpn.php
+++ b/src/OpenVpn.php
@@ -313,6 +313,11 @@ class OpenVpn
         }
 
         $routeList = $profileConfig->routes();
+        // Push extra 0.0.0.0/0 if we're the default gateway
+        // Temporary workaround for Microsoft Office on Windows
+        if ($profileConfig->defaultGateway() && !in_array('0.0.0.0/0', $routeList, true)) {
+            array_unshift($routeList, '0.0.0.0/0');
+        }
         if (0 === \count($routeList)) {
             return $routeConfig;
         }


### PR DESCRIPTION
On Windows, the internet connection is marked as "down" on VPN
connections where defaultGateway is set to true.  A workaround is to add
an extra route 0.0.0.0/0.  Ideally, the Windows client would handle
this, but as discussed in the eduVPN signal group, this can take a
while.  This workaround pushes the 0.0.0.0/0 route if the gateway is set
so that Microsoft Office works on Windows.  This change has no averse
effects on iOS, MacOS or Android.

When the Windows client handles this problem by itself, and the version
containing that fix is widely deployed, this patch can be removed again.