### PR TITLE
Add HTTP error body to error, instead of overwrite

### DIFF
--- a/libexec/server-config.php
+++ b/libexec/server-config.php
@@ -30,7 +30,10 @@ try {
     $exceptionMessage = $e->getMessage();
     if ($e instanceof HttpClientException) {
         // add the HttpClientResponse body to it
-        $exceptionMessage = (string) $e->httpClientResponse();
+        $response = (string) $e->httpClientResponse();
+        if ($response) {
+            $exceptionMessage .= " (reponse: $response)";
+        }
     }
 
     echo 'ERROR: '.$exceptionMessage.\PHP_EOL;


### PR DESCRIPTION
When an HttpClientException exception is caught by server-config.php,
then don't replace the error message with the client response, but
instead add the response to the error message.

Note that this behavior was stated by the comment, but not implemented
as such.